### PR TITLE
Bump maven shade plugin version

### DIFF
--- a/CombatTagPlus/pom.xml
+++ b/CombatTagPlus/pom.xml
@@ -28,7 +28,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.4.3</version>
+                <version>3.2.1</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <relocations>


### PR DESCRIPTION
Fix build failure: Error creating shaded jar: null: IllegalArgumentException

Fix from thread: https://stackoverflow.com/questions/49436651/error-creating-shaded-jar-null-illegalargumentexception